### PR TITLE
TOOLS-1454 Add finer versions for Shopware 5

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -2721,6 +2721,11 @@
       "sw-version-id": "\\;version:6"
     },
     "html": "<title>Shopware ([\\d\\.]+) [^<]+\\;version:\\1",
+	"dom": {
+		"div#cookie-consent.off-canvas.is--left.block-transition": {
+			"text": "\\;version:5.7"
+		}
+	},
     "icon": "Shopware.svg",
     "implies": [
       "PHP",
@@ -2744,6 +2749,10 @@
       "(?:(shopware)|/web/cache/[0-9]{10}_.+)\\.js\\;version:\\1?4:5",
       "/jquery\\.shopware\\.min\\.js",
       "/engine/Shopware/"
+    ],
+    "scripts": [
+      "var secureShop =\\;version:5.6",
+      "\\* Wrap the replacement code\\;version:5.5"
     ],
     "website": "https://www.shopware.com"
   },


### PR DESCRIPTION
Took them by inspecting https://github.com/shopware/shopware

1. DOM search for cookie consent div
Found at 5.7.8:
```
 git diff v5.7.7 v5.7.8 -- themes/Frontend/Bare/frontend/index/cookie_consent.tpl
```
2. Javascript source code
Found at 5.6.0:
```
git diff v5.5.10 v5.6.0 -- themes/Frontend/Bare/frontend/index/index.tpl
```

3. Comment in inline javascript
Found at 5.5.0:
```
git diff v5.4.6 v5.5.0 -- themes/Frontend/Bare/frontend/index/script-async-ready.tpl
```

Examples:
- link: https://www.shop.miomio.com/; expected version: >=5.5.9 <5.6.0
- link: https://www.rausch.de/; expected version: >=5.6.8 <=5.7.2 (check robots.txt)
- link: https://www.frostashop.de; expected version >=5.6.1 <5.6.5
- link: https://www.korodrogerie.de; expected version: not confirmed