### PR TITLE
TOOLS-2316-update-cpe-for-jQuery

### DIFF
--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -911,7 +911,7 @@
     "cats": [
       59
     ],
-    "cpe": "cpe:2.3:a:jquery:jquery_ui:*:*:*:*:*:*:*:*",
+    "cpe": "cpe:2.3:a:jqueryui:jquery_ui:*:*:*:*:*:*:*:*",
     "description": "jQuery UI is a collection of GUI widgets, animated visual effects, and themes implemented with jQuery, Cascading Style Sheets, and HTML.",
     "icon": "jQuery UI.svg",
     "implies": "jQuery",


### PR DESCRIPTION
Update cpe for jQuery to solve this [bug](https://pentest-tools-com.slack.com/archives/C05110M09D0/p1729170662183739).
Finding report:
![image](https://github.com/user-attachments/assets/8250bd81-abea-48cb-b26c-7cd59db19da8)

Test plan:
Go inside WSS image and run:
```
# Build local npm package located in src/drivers/npm
(cd wappalyzer_repo/ && node ./bin/link.js)
# Install from local folder
npm install ./wappalyzer_repo/src/drivers/npm/

npm --version | grep "9" && echo "You have node > 9, you can uncomment rm -rf wappalyzer_repo"
```


Commit changes and then you can light scan: https://www.tcv.vic.gov.au/ and the finding for `jquery-ui` should be available.